### PR TITLE
Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
             "FS\\SolrBundle": ""
         }
     },
-    "target-dir": "FS/Bundle/SolrBundle",
+    "target-dir": "FS/SolrBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "master"


### PR DESCRIPTION
Hi,

I'm using your bundle on a project, but I manage all my dependency bundles with composer, so,  I'm adding composer support to your bundle, but you still have to register the bundle on [packagist](https://packagist.org/) so we can install it and keep it updated by using composer.. Thanks o/
