### PR TITLE
Fixes an issue if the property name contains multiple words

### DIFF
--- a/Doctrine/Mapper/EntityMapper.php
+++ b/Doctrine/Mapper/EntityMapper.php
@@ -70,7 +70,7 @@ class EntityMapper {
 	 * @return string
 	 */
 	private function removeFieldSuffix($property) {
-		if ($pos = strpos($property, '_')) {
+		if (($pos = strrpos($property, '_')) !== false) {
 			return substr($property, 0, $pos);
 		}
 		


### PR DESCRIPTION
`album_name_s` will become `album` instead of `album_name`.

This patch fixes this behavior.
