### PR TITLE
Changed composer.json to work with newer symfony and without mongodb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
     - yes | pecl install solr-beta
     - echo "extension=solr.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
     - curl -s http://getcomposer.org/installer | php
-    - php composer.phar install    
+    - php composer.phar install --dev
 notifications:
   email:
     - fsemm.travis-ci@gmx.de    

--- a/composer.json
+++ b/composer.json
@@ -7,17 +7,24 @@
     "require": {
         "php": ">=5.3.2",
         "ext-solr": "*",
-        "symfony/framework-bundle": "2.1.*",
+        "symfony/framework-bundle": ">=2.1.0,<=2.2.x-dev",
+        "doctrine/orm": "~2.0,>=2.2.3"
+    },
+    "require-dev": {
         "doctrine/doctrine-module": "*",
         "doctrine/doctrine-orm-module": "*",
         "doctrine/mongodb": "*",
         "doctrine/mongodb-odm": "*"
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "alpha",
     "autoload": {
         "psr-0": {
             "FS\\SolrBundle": ""
         }
+    },
+    "suggest": {
+        "doctrine/mongodb": "Required if you want to use the MongoDB ODM features",
+        "doctrine/mongodb-odm": "Required if you want to use the MongoDB ODM features"
     },
     "target-dir": "FS/SolrBundle"
 }


### PR DESCRIPTION
Fixed version string for `symfony/framework-bundle`

I removed the unnnessecary Zend modules and moved them into
`require-dev`, since I couldn't find any references to the
`DoctrineModule` or `DoctrineORMModule` inside the source
code.

I moved the requirements for `doctrine/mongodb` and
`doctrine/mongodb-odm` into `require-dev` and `suggest`,
so a notice is displayed if someone wants to use it with ODM.

Also added the `dev` flag to `composer install` in `.travis.yml`
