### PR TITLE
Allow custom queries in repositories

### DIFF
--- a/Repository/Repository.php
+++ b/Repository/Repository.php
@@ -12,12 +12,12 @@ class Repository implements RepositoryInterface
     /**
      * @var Solr
      */
-    private $solr = null;
+    protected $solr = null;
 
     /**
      * @var object
      */
-    private $entity = null;
+    protected $entity = null;
 
     /**
      * @var string


### PR DESCRIPTION
Using custom repositories is kind of restricted, because we cannot create custom queries in repositories. `Repository::$solr` and `Repository::$entity` should be protected. E.g.:

``` php
class ArticleRepository extends Repository
{
    /**
     * @param string $search
     * @param int $limit
     * @param int $offset
     * @return Article[]
     */
    public function findFulltextSearch($search, $limit = 10, $offset = 0)
    {
        $this->hydrationMode = HydrationModes::HYDRATE_DOCTRINE;

        $query = $this->solr->createQuery($this->entity);
        $query->setUseAndOperator(false);
        $query->setRows($limit);
        $query->setStart($offset);
        $query->setUseWildcard(true);

        $query->addSearchTerm('id', $search);
        $query->addSearchTerm('author', $search);
        $query->addSearchTerm('title', $search);
        $query->addSearchTerm('content', $search);

        return $this->solr->query($query);
    }
}
```
