### PR TITLE
merge parent properties with child properties instead of the other way round

### DIFF
--- a/Doctrine/Annotation/AnnotationReader.php
+++ b/Doctrine/Annotation/AnnotationReader.php
@@ -236,7 +236,7 @@ class AnnotationReader
     private function readClassProperties($entity)
     {
         $reflectionClass = new \ReflectionClass($entity);
-        $inheritedProperties = array_merge($reflectionClass->getProperties(), $this->getParentProperties($reflectionClass));
+        $inheritedProperties = array_merge($this->getParentProperties($reflectionClass), $reflectionClass->getProperties());
 
         $properties = array();
         foreach ($inheritedProperties as $property) {


### PR DESCRIPTION
The method 'readClassProperties' has been written in such a way if the annotations are defined in a parent class and not in the child class, the annotations in the parent class is taken into consideration with those in the child class.

The problem is that if I have the same property in a parent and child class and only the one in the child class has the annotation, the property will not be index. 

For example, am using FOSUserBundle and I need to index username and username is defined in FOSUserBundle, one way to make SolrBundle index username is to place username in my child class and add the appropriate annotations to it.  The problem is that the annotation on the overridden property is not take into consideration.

Regards,