### PR TITLE
Related entities

### DIFF
--- a/Client/SolrBuilder.php
+++ b/Client/SolrBuilder.php
@@ -3,7 +3,7 @@
 namespace FS\SolrBundle\Client;
 
 use Solarium\Client;
-use Solarium\Core\Plugin\Plugin;
+use Solarium\Core\Plugin\AbstractPlugin;
 
 /**
  * Creates an instance of the Solarium Client
@@ -16,7 +16,7 @@ class SolrBuilder implements Builder
     private $settings = array();
 
     /**
-     * @var Plugin
+     * @var AbstractPlugin
      */
     private $plugins;
 
@@ -30,10 +30,10 @@ class SolrBuilder implements Builder
     }
 
     /**
-     * @param string $pluginName
-     * @param Plugin $plugin
+     * @param string         $pluginName
+     * @param AbstractPlugin $plugin
      */
-    public function addPlugin($pluginName, Plugin $plugin)
+    public function addPlugin($pluginName, AbstractPlugin $plugin)
     {
         $this->plugins[$pluginName] = $plugin;
     }

--- a/Debug/RequestDebugger.php
+++ b/Debug/RequestDebugger.php
@@ -5,12 +5,12 @@ namespace FS\SolrBundle\Debug;
 use Psr\Log\LoggerInterface;
 use Solarium\Core\Event\Events;
 use Solarium\Core\Event\PreExecuteRequest;
-use Solarium\Core\Plugin\Plugin;
+use Solarium\Core\Plugin\AbstractPlugin;
 
 /**
  * Listens on solarium.core.preExecuteRequest event
  */
-class RequestDebugger extends Plugin
+class RequestDebugger extends AbstractPlugin
 {
 
     /**
@@ -24,6 +24,8 @@ class RequestDebugger extends Plugin
     public function __construct(LoggerInterface $logger)
     {
         $this->logger = $logger;
+
+        return parent::__construct();
     }
 
     /**

--- a/Doctrine/Annotation/Field.php
+++ b/Doctrine/Annotation/Field.php
@@ -27,6 +27,11 @@ class Field extends Annotation
     public $boost = 0;
 
     /**
+     * @var string
+     */
+    public $getter;
+
+    /**
      * @var array
      */
     private static $TYP_MAPPING = array(
@@ -70,6 +75,16 @@ class Field extends Annotation
         }
 
         return self::$TYP_MAPPING[$this->type];
+    }
+
+    /**
+     * Related object getter name
+     *
+     * @return string
+     */
+    public function getGetterName()
+    {
+        return $this->getter;
     }
 
     /**

--- a/Doctrine/Annotation/Field.php
+++ b/Doctrine/Annotation/Field.php
@@ -27,11 +27,6 @@ class Field extends Annotation
     public $boost = 0;
 
     /**
-     * @var string
-     */
-    public $getter;
-
-    /**
      * @var array
      */
     private static $TYP_MAPPING = array(
@@ -75,16 +70,6 @@ class Field extends Annotation
         }
 
         return self::$TYP_MAPPING[$this->type];
-    }
-
-    /**
-     * Related object getter name
-     *
-     * @return string
-     */
-    public function getGetterName()
-    {
-        return $this->getter;
     }
 
     /**

--- a/Doctrine/Mapper/Mapping/MapAllFieldsCommand.php
+++ b/Doctrine/Mapper/Mapping/MapAllFieldsCommand.php
@@ -42,7 +42,7 @@ class MapAllFieldsCommand extends AbstractDocumentCommand
                     }
                     
                     $document->addField($field->getNameWithAlias(), $values, $field->getBoost());
-                } else {
+                } elseif (is_object($value) && method_exists($value, $getter)) {
                     $document->addField($field->getNameWithAlias(), $value->{$getter}(), $field->getBoost());
                 }
             } else {

--- a/Doctrine/Mapper/Mapping/MapAllFieldsCommand.php
+++ b/Doctrine/Mapper/Mapping/MapAllFieldsCommand.php
@@ -3,7 +3,7 @@ namespace FS\SolrBundle\Doctrine\Mapper\Mapping;
 
 use FS\SolrBundle\Doctrine\Annotation\Field;
 use FS\SolrBundle\Doctrine\Mapper\MetaInformationInterface;
-use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 
 /**
  * command maps all fields of the entity
@@ -35,7 +35,7 @@ class MapAllFieldsCommand extends AbstractDocumentCommand
             $value = $field->getValue();
             $getter = $field->getGetterName();
             if (!empty($getter)) {
-                if ($value instanceof ArrayCollection) {
+                if ($value instanceof Collection) {
                     $values = array();
                     foreach ($value as $relatedObj) {
                         $values[] = $relatedObj->{$getter}();

--- a/Doctrine/Mapper/Mapping/MapAllFieldsCommand.php
+++ b/Doctrine/Mapper/Mapping/MapAllFieldsCommand.php
@@ -3,6 +3,7 @@ namespace FS\SolrBundle\Doctrine\Mapper\Mapping;
 
 use FS\SolrBundle\Doctrine\Annotation\Field;
 use FS\SolrBundle\Doctrine\Mapper\MetaInformationInterface;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * command maps all fields of the entity
@@ -31,7 +32,22 @@ class MapAllFieldsCommand extends AbstractDocumentCommand
                 continue;
             }
 
-            $document->addField($field->getNameWithAlias(), $field->getValue(), $field->getBoost());
+            $value = $field->getValue();
+            $getter = $field->getGetterName();
+            if (!empty($getter)) {
+                if ($value instanceof ArrayCollection) {
+                    $values = array();
+                    foreach ($value as $relatedObj) {
+                        $values[] = $relatedObj->{$getter}();
+                    }
+                    
+                    $document->addField($field->getNameWithAlias(), $values, $field->getBoost());
+                } else {
+                    $document->addField($field->getNameWithAlias(), $value->{$getter}(), $field->getBoost());
+                }
+            } else {
+                $document->addField($field->getNameWithAlias(), $field->getValue(), $field->getBoost());
+            }
         }
 
         return $document;

--- a/Doctrine/Mapper/Mapping/MapAllFieldsCommand.php
+++ b/Doctrine/Mapper/Mapping/MapAllFieldsCommand.php
@@ -3,7 +3,6 @@ namespace FS\SolrBundle\Doctrine\Mapper\Mapping;
 
 use FS\SolrBundle\Doctrine\Annotation\Field;
 use FS\SolrBundle\Doctrine\Mapper\MetaInformationInterface;
-use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * command maps all fields of the entity
@@ -32,22 +31,7 @@ class MapAllFieldsCommand extends AbstractDocumentCommand
                 continue;
             }
 
-            $value = $field->getValue();
-            $getter = $field->getGetterName();
-            if (!empty($getter)) {
-                if ($value instanceof ArrayCollection) {
-                    $values = array();
-                    foreach ($value as $relatedObj) {
-                        $values[] = $relatedObj->{$getter}();
-                    }
-                    
-                    $document->addField($field->getNameWithAlias(), $values, $field->getBoost());
-                } else {
-                    $document->addField($field->getNameWithAlias(), $value->{$getter}(), $field->getBoost());
-                }
-            } else {
-                $document->addField($field->getNameWithAlias(), $field->getValue(), $field->getBoost());
-            }
+            $document->addField($field->getNameWithAlias(), $field->getValue(), $field->getBoost());
         }
 
         return $document;

--- a/Query/AbstractQuery.php
+++ b/Query/AbstractQuery.php
@@ -35,6 +35,24 @@ abstract class AbstractQuery extends Query
     private $metaInformation;
 
     /**
+     * @var \Solarium\QueryType\Select\Query\Query
+     */
+    private $selectQuery;
+
+
+    /**
+     * @return \Solarium\QueryType\Select\Query\Query
+     */
+    public function getSelectQuery()
+    {
+        if (!$this->selectQuery) {
+            $this->selectQuery = $this->solr->getSelectQuery($this);
+        }
+
+        return $this->selectQuery;
+    }
+
+    /**
      * @return MetaInformationInterface
      */
     public function getMetaInformation()
@@ -126,4 +144,6 @@ abstract class AbstractQuery extends Query
     {
         $this->index = $index;
     }
+
+    abstract public function prepareQuery();
 }

--- a/Query/ResultSet.php
+++ b/Query/ResultSet.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: zach
+ * Date: 12/9/15
+ * Time: 11:45 AM
+ */
+
+namespace FS\SolrBundle\Query;
+
+
+use FS\SolrBundle\Doctrine\Mapper\EntityMapper;
+use Solarium\QueryType\Select\Result\Result;
+
+/**
+ * Class ResultSet
+ *
+ * @package FS\SolrBundle\Query
+ */
+class ResultSet implements \ArrayAccess
+{
+
+    /**
+     * @var array
+     */
+    private $entities = array();
+
+    /**
+     * @var Result
+     */
+    private $response;
+
+    /**
+     * @var int
+     */
+    private $total = 0;
+
+
+    public function __construct($entity, EntityMapper $mapper, Result $response)
+    {
+        if ($mapper === null || $response === null) {
+            return $this;
+        }
+
+        $this->total = $response->getNumFound();
+        if ($this->total == 0) {
+            return $this;
+        }
+
+        $mappedEntities = array();
+        foreach ($response as $document) {
+            $mappedEntities[] = $mapper->toEntity($document, $entity);
+        }
+
+        $this->entities = $mappedEntities;
+        $this->response = $response;
+    }
+
+    /**
+     * Response getter
+     *
+     * @return Result
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+    /**
+     * Entities getter
+     *
+     * @return array
+     */
+    public function getEntities()
+    {
+        return $this->entities;
+    }
+
+    /**
+     * Entities setter
+     *
+     * @param array $entities
+     *
+     * @return ResultSet $this
+     */
+    public function setEntities($entities)
+    {
+        $this->entities = $entities;
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $offset
+     * @param mixed $value
+     */
+    public function offsetSet($offset, $value)
+    {
+        $this->entities[$offset] = $value;
+    }
+
+    /**
+     * @param mixed $offset
+     * @return mixed
+     */
+    public function offsetGet($offset)
+    {
+        return $this->entities[$offset];
+    }
+
+    /**
+     * @param mixed $offset
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->entities[$offset]);
+    }
+
+    /**
+     * @param mixed $offset
+     * @return bool
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->entities[$offset]);
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->entities;
+    }
+
+    /**
+     * @return array
+     */
+    public function __toArray()
+    {
+        return $this->toArray();
+    }
+}

--- a/Query/SolrQuery.php
+++ b/Query/SolrQuery.php
@@ -2,6 +2,8 @@
 
 namespace FS\SolrBundle\Query;
 
+use Solarium\Core\Query\Query;
+
 class SolrQuery extends AbstractQuery
 {
 
@@ -30,8 +32,10 @@ class SolrQuery extends AbstractQuery
      */
     private $customQuery;
 
+
+
     /**
-     * @return array
+     * @return ResultSet
      */
     public function getResult()
     {
@@ -144,7 +148,7 @@ class SolrQuery extends AbstractQuery
     /**
      * @return string
      */
-    public function getQuery()
+    public function prepareQuery()
     {
         if ($this->customQuery) {
             $this->setQuery($this->customQuery);
@@ -165,7 +169,7 @@ class SolrQuery extends AbstractQuery
         foreach ($this->searchTerms as $fieldName => $fieldValue) {
 
             if ($this->useWildcards) {
-                $term .= $fieldName . ':"*' . $fieldValue . '*"';
+                $term .= $fieldName . ':*' . $fieldValue . '*';
             } else {
                 $term .= $fieldName . ':"' . $fieldValue .'"';
             }
@@ -176,7 +180,6 @@ class SolrQuery extends AbstractQuery
 
             $termCount++;
         }
-
         $this->setQuery($term);
 
         return $term;


### PR DESCRIPTION
Added related entities support via adding getter name property to the Field annotation. So adding the related entity is as simple as:

```php
    /**
     * @var ArrayCollection
     *
     * @Solr\Field(type="strings", getter="getName")
     * @ORM\ManyToMany(targetEntity="Tag", inversedBy="post")
     * @ORM\JoinTable("posts_tags")
     */
    private $tags;
```