### PR TITLE
Fix show command

### DIFF
--- a/Command/ShowSchemaCommand.php
+++ b/Command/ShowSchemaCommand.php
@@ -27,7 +27,12 @@ class ShowSchemaCommand extends ContainerAwareCommand
         $metaInformationFactory = $this->getContainer()->get('solr.meta.information.factory');
 
         foreach ($namespaces->getEntityClassnames() as $classname) {
-            $metaInformation = $metaInformationFactory->loadInformation($classname);
+            try {
+                $metaInformation = $metaInformationFactory->loadInformation($classname);
+            } catch (\RuntimeException $e) {
+                $output->writeln(sprintf('<info>%s</info>', $e->getMessage()));
+                continue;
+            }
 
             $output->writeln(sprintf('<comment>%s</comment>', $classname));
             $output->writeln(sprintf('Documentname: %s', $metaInformation->getDocumentName()));

--- a/Doctrine/Mapper/MetaInformationFactory.php
+++ b/Doctrine/Mapper/MetaInformationFactory.php
@@ -50,7 +50,7 @@ class MetaInformationFactory
             if (!$reflectionClass->isInstantiable()) {
                 throw new \RuntimeException(sprintf('cannot instantiate entity %s', $className));
             }
-            $entity = new $className;
+            $entity = $reflectionClass->newInstanceWithoutConstructor();
         }
 
         if (!$this->annotationReader->hasDocumentDeclaration($entity)) {

--- a/Doctrine/Mapper/MetaInformationFactory.php
+++ b/Doctrine/Mapper/MetaInformationFactory.php
@@ -46,6 +46,10 @@ class MetaInformationFactory
         $className = $this->getClass($entity);
 
         if (!is_object($entity)) {
+            $reflectionClass = new \ReflectionClass($className);
+            if (!$reflectionClass->isInstantiable()) {
+                throw new \RuntimeException(sprintf('cannot instantiate entity %s', $className));
+            }
             $entity = new $className;
         }
 


### PR DESCRIPTION
When running `app/console solr:schema:show` I got an error for an entity which wasn't supposed to be indexed `[RuntimeException]                                                                        
  no declaration for document found in entity `

This fix will ignore this error and inform the user instead.

The second part of the fix is that the MetaInformationFactory will check if a class is instantiable, an abstract class caused a Fatal Exception with the fore mentioned fix applied.

The third commit will use the ReflectionClass to invoke an entity instance without calling the constructor, as this bundle doesn't need to know or care about constructing the complete object.

With these fixes applied I was able to run the command and get information on a per-entity basis