### PR TITLE
Index (all) entity types in batches to prevent out-of-memory issues

### DIFF
--- a/Command/SynchronizeIndexCommand.php
+++ b/Command/SynchronizeIndexCommand.php
@@ -20,7 +20,7 @@ class SynchronizeIndexCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this->setName('solr:index:populate')
-            ->addArgument('entity', InputArgument::REQUIRED, 'The entity you want to index', null)
+            ->addArgument('entity', InputArgument::OPTIONAL, 'The entity you want to index', null)
             ->addArgument('flushsize', InputArgument::OPTIONAL, 'Number of items to handle before flushing data', 500)
             ->addOption(
                 'source',

--- a/Command/SynchronizeIndexCommand.php
+++ b/Command/SynchronizeIndexCommand.php
@@ -7,6 +7,7 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -21,7 +22,13 @@ class SynchronizeIndexCommand extends ContainerAwareCommand
     {
         $this->setName('solr:index:populate')
             ->addArgument('entity', InputArgument::OPTIONAL, 'The entity you want to index', null)
-            ->addArgument('flushsize', InputArgument::OPTIONAL, 'Number of items to handle before flushing data', 500)
+            ->addOption(
+                'flushsize',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Number of items to handle before flushing data',
+                500
+            )
             ->addOption(
                 'source',
                 null,
@@ -39,7 +46,7 @@ class SynchronizeIndexCommand extends ContainerAwareCommand
     {
         $entities = $this->getIndexableEntities($input->getArgument('entity'));
         $source = $input->getOption('source');
-        $batchSize = $input->getArgument('flushsize');
+        $batchSize = $input->getOption('flushsize');
         $solr = $this->getContainer()->get('solr.client');
 
         $objectManager = $this->getObjectManager($source);
@@ -152,7 +159,7 @@ class SynchronizeIndexCommand extends ContainerAwareCommand
         foreach ($namespaces->getEntityClassnames() as $classname) {
             try {
                 $metaInformation = $metaInformationFactory->loadInformation($classname);
-                array_push($metaInformation->getClassName(), $classname);
+                array_push($entities, $metaInformation->getClassName());
             } catch (\RuntimeException $e) {
                 continue;
             }
@@ -174,7 +181,7 @@ class SynchronizeIndexCommand extends ContainerAwareCommand
     {
         $objectManager = $this->getObjectManager($source);
         $repository = $objectManager->getRepository($entity);
-        $dataStoreMetadata = $objectManager->getClassMetadata($entity);
+        $dataStoreMetadata = $objectManager->getManager()->getClassMetadata($entity);
 
         $identifierColumns = $dataStoreMetadata->getIdentifierColumnNames();
 

--- a/Command/SynchronizeIndexCommand.php
+++ b/Command/SynchronizeIndexCommand.php
@@ -20,7 +20,8 @@ class SynchronizeIndexCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this->setName('solr:index:populate')
-            ->addArgument('entity', InputArgument::REQUIRED, 'The entity you want to index')
+            ->addArgument('entity', InputArgument::REQUIRED, 'The entity you want to index', null)
+            ->addArgument('flushsize', InputArgument::OPTIONAL, 'Number of items to handle before flushing data', 500)
             ->addOption(
                 'source',
                 null,
@@ -36,66 +37,74 @@ class SynchronizeIndexCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $entity = $input->getArgument('entity');
+        $entities = $this->getIndexableEntities($input->getArgument('entity'));
         $source = $input->getOption('source');
+        $batchSize = $input->getArgument('flushsize');
+        $solr = $this->getContainer()->get('solr.client');
 
         $objectManager = $this->getObjectManager($source);
 
-        try {
-            $repository = $objectManager->getRepository($entity);
-        } catch (\Exception $e) {
-            $output->writeln(sprintf('<error>No repository found for "%s", check your input</error>', $entity));
+        foreach ($entities as $entityCollection) {
+            $output->writeln(sprintf('Indexing: <info>%s</info>', $entityCollection));
 
-            return;
-        }
-
-        $entities = $repository->findAll();
-
-        if (count($entities) == 0) {
-            $output->writeln('<comment>No entities found for indexing</comment>');
-
-            return;
-        }
-
-        $solr = $this->getContainer()->get('solr.client');
-
-        $metaInformation = $solr->getMetaFactory()->loadInformation($entity);
-
-        $output->writeln(sprintf('Synchronize <info>%s</info> entities', count($entities)));
-        $output->writeln(sprintf('Use index <info>%s</info>', $metaInformation->getIndex()));
-        $output->writeln('');
-
-        $progress = new ProgressBar($output, count($entities));
-        $progress->start();
-
-        foreach ($entities as $entity) {
             try {
-                $solr->synchronizeIndex($entity);
-
-                $progress->advance();
+                $repository = $objectManager->getRepository($entityCollection);
             } catch (\Exception $e) {
+                $output->writeln(sprintf('<error>No repository found for "%s", check your input</error>', $entityCollection));
+
+                continue;
             }
-        }
 
-        $progress->finish();
-        $output->writeln('');
-        $output->writeln('');
+            $totalSize = $this->getTotalNumberOfEntities($entityCollection, $source);
 
-        $results = $this->getContainer()->get('solr.console.command.results');
-        if ($results->hasErrors()) {
-            $output->writeln('<info>Synchronization finished with errors!</info>');
-        } else {
-            $output->writeln('<info>Synchronization successful</info>');
-        }
+            if ($totalSize === 0) {
+                $output->writeln('<comment>No entities found for indexing</comment>');
 
-        $output->writeln('');
-        $output->writeln(sprintf('Synchronized Documents: <info>%s</info>', $results->getSucceed()));
-        $output->writeln(sprintf('Not Synchronized Documents: <info>%s</info>', $results->getErrored()));
-        $output->writeln('');
+                continue;
+            }
 
-        if ($results->hasErrors()) {
-            $errorList = new ConsoleErrorListOutput($output, $this->getHelper('table'), $results->getErrors());
-            $errorList->render();
+            $metaInformation = $solr->getMetaFactory()->loadInformation($entityCollection);
+
+            $output->writeln(sprintf('Synchronize <info>%s</info> entities', $totalSize));
+            $output->writeln(sprintf('Use index <info>%s</info>', $metaInformation->getIndex()));
+            $output->writeln('');
+
+            $progress = new ProgressBar($output, $totalSize);
+            $progress->start();
+
+            $batchLoops = ceil($totalSize / $batchSize);
+
+            for ($i = 0; $i <= $batchLoops; $i++) {
+                $entities = $repository->findBy(array(), null, $batchSize, $i * $batchSize);
+                foreach ($entities as $entity) {
+                    try {
+                        $solr->synchronizeIndex($entity);
+                        $progress->advance();
+                    } catch (\Exception $e) {
+                    }
+                }
+            }
+
+            $progress->finish();
+            $output->writeln('');
+            $output->writeln('');
+
+            $results = $this->getContainer()->get('solr.console.command.results');
+            if ($results->hasErrors()) {
+                $output->writeln('<info>Synchronization finished with errors!</info>');
+            } else {
+                $output->writeln('<info>Synchronization successful</info>');
+            }
+
+            $output->writeln('');
+            $output->writeln(sprintf('Synchronized Documents: <info>%s</info>', $results->getSucceed()));
+            $output->writeln(sprintf('Not Synchronized Documents: <info>%s</info>', $results->getErrored()));
+            $output->writeln('');
+
+            if ($results->hasErrors()) {
+                $errorList = new ConsoleErrorListOutput($output, $this->getHelper('table'), $results->getErrors());
+                $errorList->render();
+            }
         }
     }
 
@@ -111,10 +120,10 @@ class SynchronizeIndexCommand extends ContainerAwareCommand
     {
         $objectManager = null;
 
-        if ($source == 'relational') {
+        if ($source === 'relational') {
             $objectManager = $this->getContainer()->get('doctrine');
         } else {
-            if ($source == 'mongodb') {
+            if ($source === 'mongodb') {
                 $objectManager = $this->getContainer()->get('doctrine_mongodb');
             } else {
                 throw new \InvalidArgumentException(sprintf('Unknown source %s', $source));
@@ -122,5 +131,64 @@ class SynchronizeIndexCommand extends ContainerAwareCommand
         }
 
         return $objectManager;
+    }
+
+    /**
+     * Get a list of entities which are indexable by Solr
+     *
+     * @param null|string $entity
+     * @return array
+     */
+    private function getIndexableEntities($entity = null)
+    {
+        if ($entity) {
+            return array($entity);
+        }
+
+        $entities = array();
+        $namespaces = $this->getContainer()->get('solr.doctrine.classnameresolver.known_entity_namespaces');
+        $metaInformationFactory = $this->getContainer()->get('solr.meta.information.factory');
+
+        foreach ($namespaces->getEntityClassnames() as $classname) {
+            try {
+                $metaInformation = $metaInformationFactory->loadInformation($classname);
+                array_push($metaInformation->getClassName(), $classname);
+            } catch (\RuntimeException $e) {
+                continue;
+            }
+        }
+
+        return $entities;
+    }
+
+    /**
+     * Get the total number of entities in a repository
+     *
+     * @param string $entity
+     * @param string $source
+     *
+     * @return int
+     * @throws \Exception
+     */
+    private function getTotalNumberOfEntities($entity, $source)
+    {
+        $objectManager = $this->getObjectManager($source);
+        $repository = $objectManager->getRepository($entity);
+        $dataStoreMetadata = $objectManager->getClassMetadata($entity);
+
+        $identifierColumns = $dataStoreMetadata->getIdentifierColumnNames();
+
+        if (!count($identifierColumns)) {
+            throw new \Exception(sprintf('No primary key found for entity %s', $entity));
+        }
+
+        $countableColumn = reset($identifierColumns);
+
+        $totalSize = $repository->createQueryBuilder('size')
+            ->select(sprintf('count(size.%s)', $countableColumn))
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return $totalSize;
     }
 }

--- a/Tests/Integration/EventDispatcherFake.php
+++ b/Tests/Integration/EventDispatcherFake.php
@@ -160,4 +160,19 @@ class EventDispatcherFake implements EventDispatcherInterface
         // TODO: Implement hasListeners() method.
     }
 
+    /**
+     * Gets the listener priority for a specific event.
+     *
+     * Returns null if the event or the listener does not exist.
+     *
+     * @param string   $eventName The name of the event
+     * @param callable $listener  The listener
+     *
+     * @return int|null The event listener priority
+     */
+    public function getListenerPriority($eventName, $listener)
+    {
+        // TODO: Implement getListenerPriority() method.
+    }
+
 } 


### PR DESCRIPTION
This PR actually does 2 things (sending in 1 PR to prevent merge-hell as both changes are on the populate command);

- Indexing hundreds of thousands of items takes a long time now and runs out of memory. This should be done in batches to prevent errors. Note; this might take a bit longer, but batch size is adjustable.
- The index command now requires a parameter and can only index on a per-entity basis. While the schema show command knows which entities are indexable. The command will need to index all of these documents when no argument is given.