### PR TITLE
Fix Symfony 2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "symfony/dependency-injection": "^2.3|^3.0",
     "symfony/http-kernel": "^2.3|^3.0",
     "symfony/config": "^2.3|^3.0",
-    "symfony/doctrine-bridge": "^3.0"
+    "symfony/doctrine-bridge": "^2.3|^3.0"
   },
   "require-dev": {
     "behat/behat": "^3.1",


### PR DESCRIPTION
With the current composer.json installation on Symfony 2 wasn't possible due to the following Composer warning;

floriansemm/solr-bundle 1.5 requires symfony/doctrine-bridge ^3.0 -> satisfiable by symfony/doctrine-bridge[v3.0.0, v3.0.1, v3.0.2, v3.0.3, v3.0.4, v3.0.5, v3.0.6].