### PR TITLE
Use identifier field names instead of column names to prevent errors

### DIFF
--- a/Command/SynchronizeIndexCommand.php
+++ b/Command/SynchronizeIndexCommand.php
@@ -156,13 +156,13 @@ class SynchronizeIndexCommand extends ContainerAwareCommand
         $repository = $objectManager->getRepository($entity);
         $dataStoreMetadata = $objectManager->getManager()->getClassMetadata($entity);
 
-        $identifierColumns = $dataStoreMetadata->getIdentifierColumnNames();
+        $identifierFieldNames = $dataStoreMetadata->getIdentifierFieldNames();
 
-        if (!count($identifierColumns)) {
+        if (!count($identifierFieldNames)) {
             throw new \Exception(sprintf('No primary key found for entity %s', $entity));
         }
 
-        $countableColumn = reset($identifierColumns);
+        $countableColumn = reset($identifierFieldNames);
 
         $totalSize = $repository->createQueryBuilder('size')
             ->select(sprintf('count(size.%s)', $countableColumn))


### PR DESCRIPTION
When using the populate command on an Entity with this id:

    /**
     * @var integer
     *
     * @Solr\Id
     *
     * @ORM\Column(name="id", type="integer")
     * @ORM\Id
     * @ORM\GeneratedValue(strategy="IDENTITY")
     */
    private $trackId;

The populate threw an Exception from Doctrine;

    Error: Class ...\.....\Entity\Track has no field or association named id 

This is because the property name differs from the column name. Since it's all Doctrine being used here the command shouldn't care about the column name, but the field name instead.