### PR TITLE
Add DSN and schema configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,11 @@ class Post
 }
 ```
 
+### `generateId` option
+
+Set this option to true and a the bundle will generate a Id for you. Use this option if you have no underlying DB which 
+ generates incremental Ids for you.
+
 ## `@Solr\Field` annotation
 
 This annotation should be added to properties that should be indexed. You should specify the `type` option for the annotation.

--- a/Solr.php
+++ b/Solr.php
@@ -136,9 +136,6 @@ class Solr implements SolrInterface
     public function getRepository($entityAlias)
     {
         $metaInformation = $this->metaInformationFactory->loadInformation($entityAlias);
-        $class = $metaInformation->getClassName();
-
-        $entity = new $class;
 
         $repositoryClass = $metaInformation->getRepository();
         if (class_exists($repositoryClass)) {

--- a/Tests/Client/Solarium/SolariumClientBuilderTest.php
+++ b/Tests/Client/Solarium/SolariumClientBuilderTest.php
@@ -54,7 +54,7 @@ class SolariumClientBuilderTest extends \PHPUnit_Framework_TestCase
      * @param string $message
      * @dataProvider dsnProvider
      */
-    public function testCreateClientDsn($dsn, $expectedBaseUri, $message)
+    public function testCreateClientWithDsn($dsn, $expectedBaseUri, $message)
     {
         $settings = $this->defaultEndpoints;
         $settings['unittest'] = [
@@ -73,7 +73,7 @@ class SolariumClientBuilderTest extends \PHPUnit_Framework_TestCase
      * @param string $message
      * @dataProvider dsnProvider
      */
-    public function testCreateClientDsnWithCore($dsn, $expectedBaseUri, $message)
+    public function testCreateClientWithDsnAndCore($dsn, $expectedBaseUri, $message)
     {
         $settings = $this->defaultEndpoints;
         $settings['unittest'] = [

--- a/Tests/Client/Solarium/SolariumClientBuilderTest.php
+++ b/Tests/Client/Solarium/SolariumClientBuilderTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace FS\SolrBundle\Tests\Client\Solarium;
+
+use FS\SolrBundle\Client\Solarium\SolariumClientBuilder;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Class SolariumClientBuilderTest
+ * @package FS\SolrBundle\Tests\Client\Solarium
+ */
+class SolariumClientBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var
+     */
+    private $defaultEndpoints;
+
+    protected function setUp()
+    {
+        $this->defaultEndpoints = [
+            'unittest' => [
+                'schema' => 'http',
+                'host' => '127.0.0.1',
+                'port' => 8983,
+                'path' => '/solr',
+                'timeout' => 5,
+                'core' => null
+            ]
+        ];
+    }
+
+    public function testCreateClientWithoutDsn()
+    {
+        $actual = $this->createClientWithSettings($this->defaultEndpoints);
+
+        $endpoint = $actual->getEndpoint('unittest');
+        $this->assertEquals('http://127.0.0.1:8983/solr/', $endpoint->getBaseUri());
+    }
+
+    public function testCreateClientWithoutDsnWithCore()
+    {
+        $this->defaultEndpoints['unittest']['core'] = 'core0';
+
+        $actual = $this->createClientWithSettings($this->defaultEndpoints);
+
+        $endpoint = $actual->getEndpoint('unittest');
+        $this->assertEquals('http://127.0.0.1:8983/solr/core0/', $endpoint->getBaseUri());
+    }
+
+    /**
+     * @param string $dsn
+     * @param string $expectedBaseUri
+     * @param string $message
+     * @dataProvider dsnProvider
+     */
+    public function testCreateClientDsn($dsn, $expectedBaseUri, $message)
+    {
+        $settings = $this->defaultEndpoints;
+        $settings['unittest'] = [
+            'dsn' => $dsn
+        ];
+
+        $actual = $this->createClientWithSettings($settings);
+
+        $endpoint = $actual->getEndpoint('unittest');
+        $this->assertEquals($expectedBaseUri, $endpoint->getBaseUri(), $message);
+    }
+
+    /**
+     * @param string $dsn
+     * @param string $expectedBaseUri
+     * @param string $message
+     * @dataProvider dsnProvider
+     */
+    public function testCreateClientDsnWithCore($dsn, $expectedBaseUri, $message)
+    {
+        $settings = $this->defaultEndpoints;
+        $settings['unittest'] = [
+            'dsn' => $dsn,
+            'core' => 'core0'
+        ];
+
+        $actual = $this->createClientWithSettings($settings);
+
+        $endpoint = $actual->getEndpoint('unittest');
+        $this->assertEquals($expectedBaseUri . 'core0/', $endpoint->getBaseUri(), $message . ' with core');
+    }
+
+    public function dsnProvider()
+    {
+        return [
+            [
+                'http://example.com:1234',
+                'http://example.com:1234/',
+                'Test DSN without path and any authentication'
+            ],
+            [
+                'http://example.com:1234/solr',
+                'http://example.com:1234/solr/',
+                'Test DSN without any authentication'
+            ],
+            [
+                'http://user@example.com:1234/solr',
+                'http://user@example.com:1234/solr/',
+                'Test DSN with user-only authentication'
+            ],
+            [
+                'http://user:secret@example.com:1234/solr',
+                'http://user:secret@example.com:1234/solr/',
+                'Test DSN with authentication'
+            ],
+            [
+                'https://example.com:1234/solr',
+                'https://example.com:1234/solr/',
+                'Test DSN with HTTPS'
+            ]
+        ];
+    }
+
+    /**
+     * @param array $settings
+     * @return \Solarium\Client
+     */
+    private function createClientWithSettings(array $settings)
+    {
+        /** @var EventDispatcherInterface $eventDispatcherMock */
+        $eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
+        return (new SolariumClientBuilder($settings, $eventDispatcherMock))->build();
+    }
+}


### PR DESCRIPTION
This PR contains 2 new configuration options, ` dsn` and `schema`.

The code for parsing the DSN has been taken from the [NelmioSolariumBundle](https://github.com/nelmio/NelmioSolariumBundle/blob/master/DependencyInjection/Configuration.php#L43), but has been placed in **SolariumClientBuilder** class, since I were unable to use [`env()` parameters](http://symfony.com/doc/current/configuration/external_parameters.html#environment-variables) when placed in the **Configuration** class (as in NelmioSolariumBundle). Maybe related to https://github.com/symfony/symfony/issues/21420