### PR TITLE
Allow the auto_index configuration to be overwritten by environment variable configuration

### DIFF
--- a/DependencyInjection/FSSolrExtension.php
+++ b/DependencyInjection/FSSolrExtension.php
@@ -29,7 +29,9 @@ class FSSolrExtension extends Extension
 
         $this->setupClients($config, $container);
 
-        $container->setParameter('solr.auto_index', $config['auto_index']);
+        if (!$container->hasParameter('solr.auto_index')) {
+            $container->setParameter('solr.auto_index', $config['auto_index']);
+        }
 
         $this->setupDoctrineListener($config, $container);
         $this->setupDoctrineConfiguration($config, $container);


### PR DESCRIPTION
This PR allows you to set the env-variable `SYMFONY__SOLR__AUTO_INDEX` to `0`, which will temporarily disable the `auto_index` configuration.

It will be helpful, and much faster, when running a console command with batch insert/update's.