### PR TITLE
Support for Virtual field for Doctrine

### DIFF
--- a/Doctrine/AbstractIndexingListener.php
+++ b/Doctrine/AbstractIndexingListener.php
@@ -57,6 +57,16 @@ class AbstractIndexingListener
             if (array_key_exists($field->name, $doctrineChangeSet)) {
                 $documentChangeSet[] = $field->name;
             }
+
+            if ($field->trackedFields != "") {
+                $trackedFields = explode(",", $field->trackedFields);
+                foreach ($trackedFields as $tf) {
+                    if (array_key_exists($tf, $doctrineChangeSet)) {
+                        $documentChangeSet[] = $field->name;
+                        break;
+                    }
+                }
+            }
         }
 
         return count($documentChangeSet) > 0;

--- a/Doctrine/Annotation/Field.php
+++ b/Doctrine/Annotation/Field.php
@@ -38,6 +38,11 @@ class Field extends Annotation
     public $fieldModifier;
 
     /**
+     * @var string
+     */
+    public $trackedFields;
+
+    /**
      * @var array
      */
     private static $TYP_MAPPING = array();
@@ -113,6 +118,16 @@ class Field extends Annotation
     public function getGetterName()
     {
         return $this->getter;
+    }
+
+    /**
+     * Field list for track
+     *
+     * @return string
+     */
+    public function getTrackedFields()
+    {
+        return $this->trackedFields;
     }
 
     /**

--- a/Doctrine/Mapper/Factory/DocumentFactory.php
+++ b/Doctrine/Mapper/Factory/DocumentFactory.php
@@ -64,7 +64,11 @@ class DocumentFactory
             } elseif (is_object($value)) {
                 $document->addField($field->getNameWithAlias(), $this->mapObject($field), $field->getBoost());
             } else {
-                $document->addField($field->getNameWithAlias(), $field->getValue(), $field->getBoost());
+                if ($getter = $field->getGetterName()) {
+                    $document->addField($field->getNameWithAlias(), $metaInformation->getEntity()->$getter(), $field->getBoost());
+                } else {
+                    $document->addField($field->getNameWithAlias(), $field->getValue(), $field->getBoost());
+                }
             }
 
             if ($field->getFieldModifier()) {


### PR DESCRIPTION
This changes make is possible to make 'virtual" field for Doctrine ORM. This code use code described here https://github.com/floriansemm/SolrBundle/issues/171 for new documents, and my code for update documents.
Added new attibute for annotation field: trackedFields. This attribute contains list of fields. If one of this fields is updated, then will updated Virtual fields in Solr

**Example:**
`/**
     * @Solr\Field(getter="getHasVideo", trackedFields="trailer,youtubeGameplay")
     *
     * @var boolean
     */
    private $hasVideo;

/**
     * Get hasVideo
     *
     * @return boolean
     */
    public function getHasVideo()
    {
        if (($this->trailer !== null && $this->trailer != "") || (count($this->youtubeGameplay) > 0)) {
            return true;
        } else {
            return false;
        }
    }
`