### PR TITLE
Jkwakman phpunit 6

### DIFF
--- a/Tests/AbstractSolrTest.php
+++ b/Tests/AbstractSolrTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Solarium\QueryType\Update\Query\Query as UpdateQuery;
 use Solarium\QueryType\Select\Query\Query as SelectQuery;
 
-abstract class AbstractSolrTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractSolrTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var MetaInformationFactory

--- a/Tests/DependencyInjection/FSSolrExtensionTest.php
+++ b/Tests/DependencyInjection/FSSolrExtensionTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @group extension
  */
-class FSSolrExtensionTest extends \PHPUnit_Framework_TestCase
+class FSSolrExtensionTest extends \PHPUnit\Framework\TestCase
 {
 
     /**

--- a/Tests/Doctrine/Annotation/AnnotationReaderTest.php
+++ b/Tests/Doctrine/Annotation/AnnotationReaderTest.php
@@ -23,7 +23,7 @@ use FS\SolrBundle\Tests\Fixtures\NotIndexedEntity;
  *
  * @group annotation
  */
-class AnnotationReaderTest extends \PHPUnit_Framework_TestCase
+class AnnotationReaderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var AnnotationReader

--- a/Tests/Doctrine/Annotation/FieldTest.php
+++ b/Tests/Doctrine/Annotation/FieldTest.php
@@ -7,7 +7,7 @@ use FS\SolrBundle\Doctrine\Annotation\Field;
  *
  * @group annotation
  */
-class FieldTest extends \PHPUnit_Framework_TestCase
+class FieldTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetNameWithAlias_String()
     {

--- a/Tests/Doctrine/ClassnameResolver/ClassnameResolverTest.php
+++ b/Tests/Doctrine/ClassnameResolver/ClassnameResolverTest.php
@@ -9,7 +9,7 @@ use FS\SolrBundle\Tests\Fixtures\ValidTestEntity;
 /**
  * @group resolver
  */
-class ClassnameResolverTest extends \PHPUnit_Framework_TestCase
+class ClassnameResolverTest extends \PHPUnit\Framework\TestCase
 {
     const ENTITY_NAMESPACE = 'FS\SolrBundle\Tests\Fixtures';
     const UNKNOW_ENTITY_NAMESPACE = 'FS\Unknown';

--- a/Tests/Doctrine/ClassnameResolver/KnownNamespaceAliasesTest.php
+++ b/Tests/Doctrine/ClassnameResolver/KnownNamespaceAliasesTest.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\Configuration as OrmConfiguration;
 use Doctrine\ODM\MongoDB\Configuration as OdmConfiguration;
 use FS\SolrBundle\Doctrine\ClassnameResolver\KnownNamespaceAliases;
 
-class KnownNamespaceAliasesTest extends \PHPUnit_Framework_TestCase
+class KnownNamespaceAliasesTest extends \PHPUnit\Framework\TestCase
 {
 
     /**

--- a/Tests/Doctrine/Hydration/DoctrineHydratorTest.php
+++ b/Tests/Doctrine/Hydration/DoctrineHydratorTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\Validator\Constraints\Valid;
 /**
  * @group hydration
  */
-class DoctrineHydratorTest extends \PHPUnit_Framework_TestCase
+class DoctrineHydratorTest extends \PHPUnit\Framework\TestCase
 {
 
     /**

--- a/Tests/Doctrine/Hydration/DoctrineValueHydratorTest.php
+++ b/Tests/Doctrine/Hydration/DoctrineValueHydratorTest.php
@@ -8,7 +8,7 @@ use FS\SolrBundle\Doctrine\Annotation\Field;
 use FS\SolrBundle\Doctrine\Hydration\DoctrineValueHydrator;
 use FS\SolrBundle\Doctrine\Mapper\MetaInformation;
 
-class DoctrineValueHydratorTest extends \PHPUnit_Framework_TestCase
+class DoctrineValueHydratorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/Tests/Doctrine/Hydration/NoDatabaseValueHydratorTest.php
+++ b/Tests/Doctrine/Hydration/NoDatabaseValueHydratorTest.php
@@ -9,7 +9,7 @@ use FS\SolrBundle\Tests\Doctrine\Mapper\SolrDocumentStub;
 use FS\SolrBundle\Tests\Fixtures\ValidTestEntity;
 use Doctrine\Common\Annotations\AnnotationReader as DoctrineAnnotationReader;
 
-class NoDatabaseValueHydratorTest extends \PHPUnit_Framework_TestCase
+class NoDatabaseValueHydratorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/Tests/Doctrine/Hydration/ValueHydratorTest.php
+++ b/Tests/Doctrine/Hydration/ValueHydratorTest.php
@@ -16,7 +16,7 @@ use FS\SolrBundle\Tests\Fixtures\ValidTestEntityWithRelation;
 /**
  * @group hydration
  */
-class ValueHydratorTest extends \PHPUnit_Framework_TestCase
+class ValueHydratorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var AnnotationReader

--- a/Tests/Doctrine/Mapper/EntityMapperTest.php
+++ b/Tests/Doctrine/Mapper/EntityMapperTest.php
@@ -29,7 +29,7 @@ use Solarium\QueryType\Update\Query\Document\Document;
  *
  * @group mapper
  */
-class EntityMapperTest extends \PHPUnit_Framework_TestCase
+class EntityMapperTest extends \PHPUnit\Framework\TestCase
 {
 
     private $doctrineHydrator = null;

--- a/Tests/Doctrine/Mapper/MetaInformationFactoryTest.php
+++ b/Tests/Doctrine/Mapper/MetaInformationFactoryTest.php
@@ -16,7 +16,7 @@ use FS\SolrBundle\Tests\Fixtures\ValidTestEntity;
  *
  * @group mapper
  */
-class MetaInformationFactoryTest extends \PHPUnit_Framework_TestCase
+class MetaInformationFactoryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var AnnotationReader

--- a/Tests/Doctrine/Mapper/MetaInformationTest.php
+++ b/Tests/Doctrine/Mapper/MetaInformationTest.php
@@ -7,7 +7,7 @@ use FS\SolrBundle\Doctrine\Mapper\MetaInformation;
  *
  * @group mapper
  */
-class MetaInformationTest extends \PHPUnit_Framework_TestCase
+class MetaInformationTest extends \PHPUnit\Framework\TestCase
 {
     private function createFieldObject($name, $value)
     {

--- a/Tests/Query/FindByDocumentNameQueryTest.php
+++ b/Tests/Query/FindByDocumentNameQueryTest.php
@@ -8,7 +8,7 @@ use Solarium\QueryType\Update\Query\Document\Document;
 /**
  * @group query
  */
-class FindByDocumentNameQueryTest extends \PHPUnit_Framework_TestCase
+class FindByDocumentNameQueryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @group query1

--- a/Tests/Query/FindByIdentifierQueryTest.php
+++ b/Tests/Query/FindByIdentifierQueryTest.php
@@ -8,7 +8,7 @@ use Solarium\QueryType\Update\Query\Document\Document;
 /**
  * @group query
  */
-class FindByIdentifierQueryTest extends \PHPUnit_Framework_TestCase
+class FindByIdentifierQueryTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testGetQuery_SearchInAllFields()

--- a/Tests/Query/QueryBuilderTest.php
+++ b/Tests/Query/QueryBuilderTest.php
@@ -7,7 +7,7 @@ use FS\SolrBundle\Doctrine\Mapper\MetaInformation;
 use FS\SolrBundle\Query\QueryBuilder;
 use FS\SolrBundle\SolrInterface;
 
-class QueryBuilderTest extends \PHPUnit_Framework_TestCase
+class QueryBuilderTest extends \PHPUnit\Framework\TestCase
 {
     private $solr;
 

--- a/Tests/Query/SolrQueryTest.php
+++ b/Tests/Query/SolrQueryTest.php
@@ -14,7 +14,7 @@ use FS\SolrBundle\SolrQueryFacade;
  *
  * @group query
  */
-class SolrQueryTest extends \PHPUnit_Framework_TestCase
+class SolrQueryTest extends \PHPUnit\Framework\TestCase
 {
 
     private function getFieldMapping()

--- a/Tests/Repository/RepositoryTest.php
+++ b/Tests/Repository/RepositoryTest.php
@@ -21,7 +21,7 @@ use FS\SolrBundle\Tests\Fixtures\ValidTestEntity;
 /**
  * @group repository
  */
-class RepositoryTest extends \PHPUnit_Framework_TestCase
+class RepositoryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var MetaTestInformationFactory

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "doctrine/mongodb-odm-bundle": "*",
     "doctrine/orm": "^2.3",
     "phpunit/phpunit": "^6",
-    "codedungeon/phpunit-result-printer": "^0.8.3"
+    "codedungeon/phpunit-result-printer": "0.8.3"
   },
   "minimum-stability": "RC",
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "behat/behat": "^3.1",
     "doctrine/mongodb-odm-bundle": "*",
     "doctrine/orm": "^2.3",
-    "phpunit/phpunit": "^5.4"
+    "phpunit/phpunit": "^6"
   },
   "minimum-stability": "RC",
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "behat/behat": "^3.1",
     "doctrine/mongodb-odm-bundle": "*",
     "doctrine/orm": "^2.3",
-    "phpunit/phpunit": "^6"
+    "phpunit/phpunit": "^6",
+    "codedungeon/phpunit-result-printer": "^0.19.10"
   },
   "minimum-stability": "RC",
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "doctrine/mongodb-odm-bundle": "*",
     "doctrine/orm": "^2.3",
     "phpunit/phpunit": "^6",
-    "codedungeon/phpunit-result-printer": "^0.19.10"
+    "codedungeon/phpunit-result-printer": "^0.8.0"
   },
   "minimum-stability": "RC",
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "doctrine/mongodb-odm-bundle": "*",
     "doctrine/orm": "^2.3",
     "phpunit/phpunit": "^6",
-    "codedungeon/phpunit-result-printer": "^0.8.0"
+    "codedungeon/phpunit-result-printer": "^0.8.3"
   },
   "minimum-stability": "RC",
   "autoload": {

--- a/phpunit-printer.yml
+++ b/phpunit-printer.yml
@@ -1,0 +1,12 @@
+options:
+  cd-printer-hide-class: false
+  cd-printer-simple-output: false
+  cd-printer-show-config: true
+  cd-printer-hide-namespace: false
+markers:
+  cd-pass: "✓ "
+  cd-fail: "✖ "
+  cd-error: "⚈ "
+  cd-skipped: "→ "
+  cd-incomplete: "∅ "
+  cd-risky: "⌽ "

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
          stopOnFailure="false"
          syntaxCheck="false"
          bootstrap="Tests/bootstrap.php"
+         printerClass="Codedungeon\PHPUnitPrettyResultPrinter\Printer"
         >
 
     <testsuites>


### PR DESCRIPTION
PHPUnit v5 namespace is deprecated. Changed it to the PHPUnit v6 namespace. Support for PHPUnit 6 ends on 1 feb 2019. Updated the composer file to install PHPUnit v6.  Also added codedungeon PHPUnit pretty printer for a modern, pretty PHPUnit result printer. 