### PR TITLE
Jkwakman field alias doctrine relation

### DIFF
--- a/Doctrine/Annotation/Field.php
+++ b/Doctrine/Annotation/Field.php
@@ -38,6 +38,11 @@ class Field extends Annotation
     public $fieldModifier;
 
     /**
+     * @var string|bool
+     */
+    public $fieldAlias = false;
+    
+    /**
      * @var array
      */
     private static $TYP_MAPPING = array();
@@ -82,6 +87,10 @@ class Field extends Annotation
      */
     public function getNameWithAlias()
     {
+        if($this->fieldAlias) {
+            return $this->normalizeName($this->fieldAlias) . $this->getTypeSuffix($this->type);
+        }
+        
         return $this->normalizeName($this->name) . $this->getTypeSuffix($this->type);
     }
 

--- a/README.md
+++ b/README.md
@@ -285,8 +285,10 @@ class Tag
         return $this->name;
     }
 }
+```
 
 To define an alias field name for the database entry you can use the fieldAlias in the @Solr\Field tag. 
+
 
 ```php
 /**
@@ -299,7 +301,6 @@ To define an alias field name for the database entry you can use the fieldAlias 
 private $tags;
 ```
 
-```
 
 [For more information read the more detailed "How to index relation" guide](Resources/doc/index_relations.md)
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,20 @@ class Tag
         return $this->name;
     }
 }
+
+To define an alias field name for the database entry you can use the fieldAlias in the @Solr\Field tag. 
+
+```php
+/**
+ * @var Tag[]
+ *
+ * @Solr\Field(type="strings", getter="getName", fieldAlias="availableTags")
+ *
+ * @ORM\OneToMany(targetEntity="Acme\DemoBundle\Entity\Tag", mappedBy="post", cascade={"persist"})
+ */
+private $tags;
+```
+
 ```
 
 [For more information read the more detailed "How to index relation" guide](Resources/doc/index_relations.md)

--- a/README.md
+++ b/README.md
@@ -287,8 +287,9 @@ class Tag
 }
 ```
 
-To define an alias field name for the database entry you can use the fieldAlias in the @Solr\Field tag. 
+### `fieldAlias' property
 
+To define an alias field name for the database entry you can use the fieldAlias in the @Solr\Field tag. 
 
 ```php
 /**
@@ -300,7 +301,15 @@ To define an alias field name for the database entry you can use the fieldAlias 
  */
 private $tags;
 ```
+The database record will now be saved with the availabele_tags property instead of tags:
 
+```json
+{
+    "id":"category_1",
+    "name_s": "Category",
+    "available_tags_ss":["tag1","tag2"]
+}
+```
 
 [For more information read the more detailed "How to index relation" guide](Resources/doc/index_relations.md)
 

--- a/Tests/Doctrine/Annotation/FieldTest.php
+++ b/Tests/Doctrine/Annotation/FieldTest.php
@@ -44,7 +44,13 @@ class FieldTest extends \PHPUnit_Framework_TestCase
         $field = new Field(array('name' => 'test', 'type' => 'integer'));
         $this->assertEquals('test_i', $field->getNameWithAlias());
     }
-
+    
+    public function testGetNameWithFieldAlias_String()
+    {
+       $field = new Field(array('name' => 'test', 'type' => 'string', 'fieldAlias' => 'alias'));
+       $this->assertEquals('alias_s', $field->getNameWithAlias());
+    }
+    
     public function testNormalizeName_CamelCase()
     {
         $field = new Field(array('name' => 'testCamelCase', 'type' => 'string'));


### PR DESCRIPTION
When using the OnetoMany relation we often do not want the parameter name as the fieldname in the Solr database. For example..

Company -> Orders ($orders) -> getOrderNumber()

Here the fieldname will be casted to orders_ss in the solr_database. Instead we want order_id_ss.

To arrange this behaviour we added the fieldAlias in the annotation.

 * @solr\Field(type="strings", getter="getOrderId", fieldAlias="order_id")